### PR TITLE
Add Copilot CLI session audit hooks with pluggable destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,19 @@ All scripts were generated with the assistance of GitHub Copilot.
 
 ## 📊 [Copilot Analytics](./copilot/)
 
+### Session Audit Hooks
+- [`copilot/hooks/`](./copilot/hooks/) - **Copilot CLI Session Audit** - Automatically capture and upload Copilot CLI chat session data for auditing and compliance. Supports multiple destinations: local file, HTTP webhook, Datadog, Splunk, and AWS S3. **[Full Documentation →](./copilot/hooks/README.md)**
+   ```bash
+   # Copy hooks into your repo
+   cp copilot/hooks/hooks.json .github/hooks/
+   cp copilot/hooks/upload-session-audit.sh .github/hooks/
+   chmod +x .github/hooks/upload-session-audit.sh
+
+   # Set destination (file, http, datadog, splunk, s3)
+   export COPILOT_AUDIT_DEST="datadog"
+   export DD_API_KEY="your-key"
+   ```
+
 ### Bash Scripts (Recommended)
 - [`inactive_copilot.sh`](./copilot/inactive_copilot.sh) - Identifies Copilot users active and inactive within 90 days
 - [`compare_ghe_copilot_licenses.sh`](./compare_ghe_copilot_licenses.sh) - **License Gap Analysis** - Compares GitHub Enterprise Managed Users with Copilot licenses to identify users who have enterprise licenses but no Copilot license. Perfect for license optimization and provisioning planning.

--- a/copilot/hooks/README.md
+++ b/copilot/hooks/README.md
@@ -163,7 +163,7 @@ Every captured session produces this JSON structure:
 
 ## Available Hook Events
 
-The `hooks.json` in this example uses three events, but Copilot CLI supports six:
+The `hooks.json` in this example uses only `sessionEnd` (since the audit upload captures the full session retroactively), but Copilot CLI supports six hook events:
 
 | Event | When It Fires | Can Block? |
 |---|---|---|

--- a/copilot/hooks/README.md
+++ b/copilot/hooks/README.md
@@ -1,0 +1,209 @@
+# Copilot CLI Session Audit Hooks
+
+Automatically capture and upload Copilot CLI session data for auditing and compliance when a session ends.
+
+## How It Works
+
+GitHub Copilot CLI stores all session data locally in `~/.copilot/session-store.db` (SQLite). These hooks tap into the CLI's [hook system](https://docs.github.com/en/copilot/reference/hooks-configuration) to extract and ship that data to a log aggregator on session end.
+
+```
+┌──────────────┐     ┌───────────────────┐     ┌─────────────────────┐
+│  Copilot CLI  │────▶│  sessionEnd hook   │────▶│  Audit Destination  │
+│  session ends │     │  (hooks.json)      │     │  (file/http/dd/...)  │
+└──────────────┘     └───────────────────┘     └─────────────────────┘
+                            │
+                            ▼
+                     ┌───────────────────┐
+                     │  session-store.db  │
+                     │  (local SQLite)    │
+                     └───────────────────┘
+```
+
+## Quick Start
+
+### 1. Copy the hooks into your repo
+
+```bash
+# From your repository root
+mkdir -p .github/hooks
+cp hooks.json .github/hooks/
+cp upload-session-audit.sh .github/hooks/
+chmod +x .github/hooks/upload-session-audit.sh
+```
+
+### 2. Set your destination
+
+```bash
+# Default: writes JSON files to ~/.copilot/audit-logs/
+export COPILOT_AUDIT_DEST="file"
+
+# Or ship to Datadog, Splunk, S3, or any HTTP endpoint (see below)
+```
+
+### 3. That's it
+
+Every Copilot CLI session will now be automatically captured when it ends.
+
+## Prerequisites
+
+- **`sqlite3`** — for reading the session store
+- **`jq`** — for JSON processing
+- **`curl`** — for HTTP-based destinations
+- **`aws`** — only for the S3 destination
+
+## Supported Destinations
+
+Configure via the `COPILOT_AUDIT_DEST` environment variable:
+
+### Local File (default)
+
+Writes each session as a standalone JSON file. Good for development or as a starting point.
+
+```bash
+export COPILOT_AUDIT_DEST="file"
+export COPILOT_AUDIT_DIR="$HOME/.copilot/audit-logs"  # optional, this is the default
+```
+
+Output: `~/.copilot/audit-logs/session-<uuid>.json`
+
+### HTTP Webhook
+
+POST the payload to any REST endpoint — works with custom compliance APIs, Azure Monitor ingestion, etc.
+
+```bash
+export COPILOT_AUDIT_DEST="http"
+export COPILOT_AUDIT_URL="https://your-api.example.com/v1/audit"
+export COPILOT_AUDIT_AUTH_HEADER="Bearer your-token"  # optional
+```
+
+### Datadog
+
+Send to [Datadog Logs](https://docs.datadoghq.com/logs/).
+
+```bash
+export COPILOT_AUDIT_DEST="datadog"
+export DD_API_KEY="your-datadog-api-key"
+export DD_SITE="datadoghq.com"  # optional, default shown
+export DD_ENV="production"       # optional, tagged as env:production
+```
+
+Search in Datadog: `source:copilot-cli service:copilot-cli`
+
+### Splunk
+
+Send to [Splunk HTTP Event Collector](https://docs.splunk.com/Documentation/Splunk/latest/Data/UsetheHTTPEventCollector).
+
+```bash
+export COPILOT_AUDIT_DEST="splunk"
+export SPLUNK_HEC_URL="https://your-splunk:8088/services/collector/event"
+export SPLUNK_HEC_TOKEN="your-hec-token"
+```
+
+Search in Splunk: `sourcetype="copilot:session"`
+
+### AWS S3
+
+Upload JSON files to an S3 bucket (requires [AWS CLI](https://aws.amazon.com/cli/) with configured credentials).
+
+```bash
+export COPILOT_AUDIT_DEST="s3"
+export COPILOT_AUDIT_S3_BUCKET="my-audit-bucket"
+export COPILOT_AUDIT_S3_PREFIX="copilot-audit"  # optional, default shown
+```
+
+Files organized by date: `s3://bucket/copilot-audit/2026/03/21/session-<uuid>.json`
+
+## Audit Payload
+
+Every captured session produces this JSON structure:
+
+```json
+{
+  "schemaVersion": "1.0",
+  "sessionId": "90856c5e-c613-4756-af20-1810695bb70c",
+  "repository": "octocat/my-project",
+  "branch": "main",
+  "cwd": "/Users/dev/my-project",
+  "user": "octocat",
+  "hostType": "cli",
+  "summary": "Implemented authentication middleware",
+  "startedAt": "2026-03-21T10:00:00.000Z",
+  "endedAt": "2026-03-21T10:45:00.000Z",
+  "endReason": "complete",
+  "turnCount": 8,
+  "turns": [
+    {
+      "turn_index": 0,
+      "user_message": "Help me add JWT auth",
+      "assistant_response": "I'll help you set up...",
+      "timestamp": "2026-03-21T10:00:05.000Z"
+    }
+  ],
+  "checkpoints": [
+    {
+      "checkpoint_number": 1,
+      "title": "Initial setup",
+      "overview": "Created auth middleware and tests"
+    }
+  ]
+}
+```
+
+| Field | Description |
+|---|---|
+| `schemaVersion` | Payload format version (`"1.0"`) |
+| `sessionId` | UUID of the Copilot CLI session |
+| `repository` | GitHub repository (owner/name) |
+| `branch` | Git branch active during session |
+| `user` | OS username (`$USER`) |
+| `summary` | AI-generated session summary |
+| `endReason` | `complete`, `error`, `abort`, `timeout`, or `user_exit` |
+| `turns` | Full user/assistant conversation history |
+| `checkpoints` | Session checkpoints (title + overview) |
+
+## Available Hook Events
+
+The `hooks.json` in this example uses three events, but Copilot CLI supports six:
+
+| Event | When It Fires | Can Block? |
+|---|---|---|
+| `sessionStart` | New or resumed session | No |
+| `userPromptSubmitted` | User submits a prompt | No |
+| `preToolUse` | Before tool execution | **Yes** — can deny |
+| `postToolUse` | After tool execution | No |
+| `errorOccurred` | On agent error | No |
+| `sessionEnd` | Session completes/ends | No |
+
+See the [Hooks Configuration Reference](https://docs.github.com/en/copilot/reference/hooks-configuration) for full details on input/output schemas.
+
+## Security Considerations
+
+1. **Credentials** — Never hard-code API keys. Use environment variables, 1Password CLI, AWS Secrets Manager, or HashiCorp Vault.
+2. **Sensitive data** — Session turns may contain code, file contents, or error messages. Restrict access to your audit destination and consider data retention policies.
+3. **Network** — HTTP destinations use a 30-second timeout to avoid blocking the developer.
+4. **Local data** — The session data already exists locally in `~/.copilot/session-store.db`. These hooks add *transport*, not new data collection.
+
+## Customization
+
+The upload script is intentionally straightforward Bash. Common customizations:
+
+- **Add redaction**: Pipe the payload through a sanitization step before upload
+- **Add metadata**: Include team name, cost center, or environment tags
+- **Filter sessions**: Skip short sessions (e.g., `turnCount < 2`)
+- **Change format**: Convert to CSV, Parquet, or your org's preferred format
+
+## Troubleshooting
+
+| Error | Fix |
+|---|---|
+| `'sqlite3' not found` | `brew install sqlite3` (macOS) or `sudo apt install sqlite3` (Linux) |
+| `'jq' not found` | `brew install jq` (macOS) or `sudo apt install jq` (Linux) |
+| `session store not found` | Run at least one Copilot CLI session first |
+| `Unknown COPILOT_AUDIT_DEST` | Set to one of: `file`, `http`, `datadog`, `splunk`, `s3` |
+| HTTP uploads failing | Check URL reachability and auth token validity |
+
+## References
+
+- [About Copilot CLI Hooks](https://docs.github.com/en/copilot/concepts/agents/coding-agent/about-hooks)
+- [Hooks Configuration Reference](https://docs.github.com/en/copilot/reference/hooks-configuration)
+- [Using Hooks with Copilot CLI (Tutorial)](https://docs.github.com/en/copilot/tutorials/copilot-cli-hooks)

--- a/copilot/hooks/hooks.json
+++ b/copilot/hooks/hooks.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      {
+        "type": "command",
+        "bash": "echo \"[$(date)] Session started\" >> .agent.log",
+        "powershell": "Add-Content -Path .agent.log -Value \"[$(Get-Date)] Session started\"",
+        "cwd": ".",
+        "timeoutSec": 10
+      }
+    ],
+    "userPromptSubmitted": [
+      {
+        "type": "command",
+        "bash": "echo \"[$(date)] Prompt: $(cat | jq -r '.prompt')\" >> .agent.log",
+        "powershell": "$input | ConvertFrom-Json | ForEach-Object { Add-Content -Path .agent.log -Value \"[$(Get-Date)] Prompt: $($_.prompt)\" }",
+        "cwd": ".",
+        "timeoutSec": 30
+      }
+    ],
+    "sessionEnd": [
+      {
+        "type": "command",
+        "bash": "echo \"[$(date)] Session ended ($(cat | jq -r '.reason'))\" >> .agent.log",
+        "powershell": "$input | ConvertFrom-Json | ForEach-Object { Add-Content -Path .agent.log -Value \"[$(Get-Date)] Session ended ($($_.reason))\" }",
+        "cwd": ".",
+        "timeoutSec": 10
+      },
+      {
+        "type": "command",
+        "bash": ".github/hooks/upload-session-audit.sh",
+        "comment": "Upload full session data to configured audit destination (set COPILOT_AUDIT_DEST env var)",
+        "cwd": ".",
+        "timeoutSec": 60
+      }
+    ]
+  }
+}

--- a/copilot/hooks/hooks.json
+++ b/copilot/hooks/hooks.json
@@ -1,32 +1,8 @@
 {
   "version": 1,
+  "comment": "Only sessionEnd is needed — the audit upload script captures the full session (all turns, prompts, timestamps, checkpoints) from the local session store. Per-event logging (sessionStart, userPromptSubmitted) was removed as redundant.",
   "hooks": {
-    "sessionStart": [
-      {
-        "type": "command",
-        "bash": "echo \"[$(date)] Session started\" >> .agent.log",
-        "powershell": "Add-Content -Path .agent.log -Value \"[$(Get-Date)] Session started\"",
-        "cwd": ".",
-        "timeoutSec": 10
-      }
-    ],
-    "userPromptSubmitted": [
-      {
-        "type": "command",
-        "bash": "echo \"[$(date)] Prompt: $(cat | jq -r '.prompt')\" >> .agent.log",
-        "powershell": "$input | ConvertFrom-Json | ForEach-Object { Add-Content -Path .agent.log -Value \"[$(Get-Date)] Prompt: $($_.prompt)\" }",
-        "cwd": ".",
-        "timeoutSec": 30
-      }
-    ],
     "sessionEnd": [
-      {
-        "type": "command",
-        "bash": "echo \"[$(date)] Session ended ($(cat | jq -r '.reason'))\" >> .agent.log",
-        "powershell": "$input | ConvertFrom-Json | ForEach-Object { Add-Content -Path .agent.log -Value \"[$(Get-Date)] Session ended ($($_.reason))\" }",
-        "cwd": ".",
-        "timeoutSec": 10
-      },
       {
         "type": "command",
         "bash": ".github/hooks/upload-session-audit.sh",

--- a/copilot/hooks/upload-session-audit.sh
+++ b/copilot/hooks/upload-session-audit.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# upload-session-audit.sh
+#
+# Extracts the most recent Copilot CLI session from the local session store
+# and uploads the full conversation payload to a configurable destination.
+#
+# Usage:
+#   Copy this script and hooks.json into your repo's .github/hooks/ directory.
+#   Set COPILOT_AUDIT_DEST to choose where audit data is sent.
+#
+# Destinations (via COPILOT_AUDIT_DEST env var):
+#   file     - Write JSON to local audit log directory (default)
+#   http     - POST to a generic HTTP/REST endpoint
+#   datadog  - Send to Datadog Logs API
+#   splunk   - Send to Splunk HTTP Event Collector (HEC)
+#   s3       - Upload to an AWS S3 bucket
+#
+# Environment Variables:
+#   COPILOT_AUDIT_DEST          - Destination type (default: "file")
+#   COPILOT_AUDIT_DIR           - Local file output dir (default: ~/.copilot/audit-logs)
+#   COPILOT_AUDIT_URL           - HTTP endpoint URL (required for http dest)
+#   COPILOT_AUDIT_AUTH_HEADER   - HTTP Authorization header value (optional)
+#   DD_API_KEY                  - Datadog API key (required for datadog dest)
+#   DD_SITE                     - Datadog site (default: datadoghq.com)
+#   DD_ENV                      - Datadog environment tag (default: dev)
+#   SPLUNK_HEC_URL              - Splunk HEC endpoint (required for splunk dest)
+#   SPLUNK_HEC_TOKEN            - Splunk HEC token (required for splunk dest)
+#   COPILOT_AUDIT_S3_BUCKET     - S3 bucket name (required for s3 dest)
+#   COPILOT_AUDIT_S3_PREFIX     - S3 key prefix (default: copilot-audit)
+#   COPILOT_HOME                - Copilot config directory (default: ~/.copilot)
+
+COPILOT_HOME="${COPILOT_HOME:-$HOME/.copilot}"
+SESSION_DB="${COPILOT_HOME}/session-store.db"
+AUDIT_DEST="${COPILOT_AUDIT_DEST:-file}"
+AUDIT_DIR="${COPILOT_AUDIT_DIR:-$COPILOT_HOME/audit-logs}"
+
+# Read hook input from stdin (sessionEnd provides timestamp, cwd, reason)
+HOOK_INPUT=$(cat)
+END_REASON=$(echo "$HOOK_INPUT" | jq -r '.reason // "unknown"')
+
+# --- Dependency checks ---
+for cmd in sqlite3 jq; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "⚠️  Audit upload skipped: '$cmd' not found" >&2
+    exit 0
+  fi
+done
+
+if [[ ! -f "$SESSION_DB" ]]; then
+  echo "⚠️  Audit upload skipped: session store not found at $SESSION_DB" >&2
+  exit 0
+fi
+
+# --- Extract session data from the local SQLite store ---
+
+# Get the most recently updated session (the one that just ended)
+SESSION_ROW=$(sqlite3 -json "$SESSION_DB" \
+  "SELECT id, cwd, repository, branch, summary, host_type, created_at, updated_at
+   FROM sessions ORDER BY updated_at DESC LIMIT 1;" 2>/dev/null)
+
+if [[ -z "$SESSION_ROW" || "$SESSION_ROW" == "[]" ]]; then
+  echo "⚠️  Audit upload skipped: no sessions found in store" >&2
+  exit 0
+fi
+
+SESSION_ID=$(echo "$SESSION_ROW" | jq -r '.[0].id')
+
+# Extract conversation turns (sqlite3 -json returns empty string for 0 rows)
+TURNS=$(sqlite3 -json "$SESSION_DB" \
+  "SELECT turn_index, user_message, assistant_response, timestamp
+   FROM turns WHERE session_id = '$SESSION_ID'
+   ORDER BY turn_index;" 2>/dev/null)
+[[ -z "$TURNS" ]] && TURNS="[]"
+
+# Extract checkpoints
+CHECKPOINTS=$(sqlite3 -json "$SESSION_DB" \
+  "SELECT checkpoint_number, title, overview
+   FROM checkpoints WHERE session_id = '$SESSION_ID'
+   ORDER BY checkpoint_number;" 2>/dev/null)
+[[ -z "$CHECKPOINTS" ]] && CHECKPOINTS="[]"
+
+TURN_COUNT=$(echo "$TURNS" | jq 'length')
+
+# --- Build the standardized audit payload ---
+PAYLOAD=$(jq -n \
+  --arg schema_version "1.0" \
+  --arg session_id "$SESSION_ID" \
+  --arg repository "$(echo "$SESSION_ROW" | jq -r '.[0].repository // empty')" \
+  --arg branch "$(echo "$SESSION_ROW" | jq -r '.[0].branch // empty')" \
+  --arg cwd "$(echo "$SESSION_ROW" | jq -r '.[0].cwd // empty')" \
+  --arg user "${USER:-unknown}" \
+  --arg host_type "$(echo "$SESSION_ROW" | jq -r '.[0].host_type // "cli"')" \
+  --arg summary "$(echo "$SESSION_ROW" | jq -r '.[0].summary // empty')" \
+  --arg started_at "$(echo "$SESSION_ROW" | jq -r '.[0].created_at // empty')" \
+  --arg ended_at "$(echo "$SESSION_ROW" | jq -r '.[0].updated_at // empty')" \
+  --arg end_reason "$END_REASON" \
+  --argjson turn_count "$TURN_COUNT" \
+  --argjson turns "$TURNS" \
+  --argjson checkpoints "$CHECKPOINTS" \
+  '{
+    schemaVersion: $schema_version,
+    sessionId: $session_id,
+    repository: $repository,
+    branch: $branch,
+    cwd: $cwd,
+    user: $user,
+    hostType: $host_type,
+    summary: $summary,
+    startedAt: $started_at,
+    endedAt: $ended_at,
+    endReason: $end_reason,
+    turnCount: $turn_count,
+    turns: $turns,
+    checkpoints: $checkpoints
+  }')
+
+# --- Destination handlers ---
+
+upload_to_file() {
+  mkdir -p "$AUDIT_DIR"
+  local filename="${AUDIT_DIR}/session-${SESSION_ID}.json"
+  echo "$PAYLOAD" > "$filename"
+  echo "✅ Audit log saved to $filename"
+}
+
+upload_to_http() {
+  local url="${COPILOT_AUDIT_URL:?COPILOT_AUDIT_URL is required when COPILOT_AUDIT_DEST=http}"
+  local status
+  status=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "$url" \
+    -H "Content-Type: application/json" \
+    ${COPILOT_AUDIT_AUTH_HEADER:+-H "Authorization: $COPILOT_AUDIT_AUTH_HEADER"} \
+    -d "$PAYLOAD" \
+    --max-time 30)
+
+  if [[ "$status" -ge 200 && "$status" -lt 300 ]]; then
+    echo "✅ Audit log uploaded to HTTP endpoint (HTTP $status)"
+  else
+    echo "⚠️  Audit upload failed: HTTP $status" >&2
+  fi
+}
+
+upload_to_datadog() {
+  local api_key="${DD_API_KEY:?DD_API_KEY is required when COPILOT_AUDIT_DEST=datadog}"
+  local site="${DD_SITE:-datadoghq.com}"
+  local url="https://http-intake.logs.${site}/api/v2/logs"
+
+  local dd_payload
+  dd_payload=$(jq -n \
+    --arg ddsource "copilot-cli" \
+    --arg ddtags "env:${DD_ENV:-dev},service:copilot-cli" \
+    --arg hostname "$(hostname)" \
+    --arg service "copilot-cli" \
+    --argjson message "$PAYLOAD" \
+    '[{
+      ddsource: $ddsource,
+      ddtags: $ddtags,
+      hostname: $hostname,
+      service: $service,
+      message: $message
+    }]')
+
+  local status
+  status=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "$url" \
+    -H "Content-Type: application/json" \
+    -H "DD-API-KEY: $api_key" \
+    -d "$dd_payload" \
+    --max-time 30)
+
+  if [[ "$status" -ge 200 && "$status" -lt 300 ]]; then
+    echo "✅ Audit log sent to Datadog (HTTP $status)"
+  else
+    echo "⚠️  Datadog upload failed: HTTP $status" >&2
+  fi
+}
+
+upload_to_splunk() {
+  local hec_url="${SPLUNK_HEC_URL:?SPLUNK_HEC_URL is required when COPILOT_AUDIT_DEST=splunk}"
+  local hec_token="${SPLUNK_HEC_TOKEN:?SPLUNK_HEC_TOKEN is required when COPILOT_AUDIT_DEST=splunk}"
+
+  local splunk_payload
+  splunk_payload=$(jq -n \
+    --arg sourcetype "copilot:session" \
+    --arg source "copilot-cli" \
+    --argjson event "$PAYLOAD" \
+    '{
+      sourcetype: $sourcetype,
+      source: $source,
+      event: $event
+    }')
+
+  local status
+  status=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X POST "$hec_url" \
+    -H "Authorization: Splunk $hec_token" \
+    -H "Content-Type: application/json" \
+    -d "$splunk_payload" \
+    --max-time 30)
+
+  if [[ "$status" -ge 200 && "$status" -lt 300 ]]; then
+    echo "✅ Audit log sent to Splunk HEC (HTTP $status)"
+  else
+    echo "⚠️  Splunk upload failed: HTTP $status" >&2
+  fi
+}
+
+upload_to_s3() {
+  local bucket="${COPILOT_AUDIT_S3_BUCKET:?COPILOT_AUDIT_S3_BUCKET is required when COPILOT_AUDIT_DEST=s3}"
+  local prefix="${COPILOT_AUDIT_S3_PREFIX:-copilot-audit}"
+  local key="${prefix}/$(date +%Y/%m/%d)/session-${SESSION_ID}.json"
+
+  if ! command -v aws &>/dev/null; then
+    echo "⚠️  Audit upload skipped: 'aws' CLI not found" >&2
+    exit 0
+  fi
+
+  echo "$PAYLOAD" | aws s3 cp - "s3://${bucket}/${key}" \
+    --content-type "application/json" \
+    --quiet
+
+  echo "✅ Audit log uploaded to s3://${bucket}/${key}"
+}
+
+# --- Route to the configured destination ---
+case "$AUDIT_DEST" in
+  file)    upload_to_file ;;
+  http)    upload_to_http ;;
+  datadog) upload_to_datadog ;;
+  splunk)  upload_to_splunk ;;
+  s3)      upload_to_s3 ;;
+  *)
+    echo "⚠️  Unknown COPILOT_AUDIT_DEST='$AUDIT_DEST'. Valid: file, http, datadog, splunk, s3" >&2
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Introduce hooks for capturing and uploading Copilot CLI session data for auditing and compliance. Support multiple destinations including local files, HTTP webhooks, Datadog, Splunk, and AWS S3. Include setup instructions and a reference implementation.